### PR TITLE
Account for incosistencies of mime-types between rww-play and banana-rdf

### DIFF
--- a/app/rww/ldp/WebClient.scala
+++ b/app/rww/ldp/WebClient.scala
@@ -8,12 +8,13 @@ import com.ning.http.util.DateUtil
 import org.slf4j.LoggerFactory
 import org.w3.banana._
 import org.w3.banana.io._
-import org.w3.play.api.libs.ws.{Response, ResponseHeaders, WS}
-import rww.ldp.model.{RemoteLDPR, _}
+import org.w3.play.api.libs.ws.{ Response, ResponseHeaders, WS }
+import _root_.play.api.Play.current
+import rww.ldp.model.{ RemoteLDPR, _ }
 
 import scala.collection.immutable
-import scala.concurrent.{ExecutionContext, Future}
-import scala.util.{Failure, Success, Try}
+import scala.concurrent.{ ExecutionContext, Future }
+import scala.util.{ Failure, Success, Try }
 
 /**
  * A Web Client interacts directly with http resources on the web.
@@ -26,12 +27,11 @@ trait WebClient[Rdf <: RDF] {
 
   def get(url: Rdf#URI): Future[NamedResource[Rdf]]
 
-  def post[S](url: Rdf#URI, slug: Option[String], graph: Rdf#Graph, syntax: Syntax[S])
-             (implicit writer: Writer[Rdf#Graph, Try, S]): Future[Rdf#URI]
+  def post[S](url: Rdf#URI, slug: Option[String], graph: Rdf#Graph, syntax: Syntax[S])(implicit writer: Writer[Rdf#Graph, Try, S]): Future[Rdf#URI]
 
   def delete(url: Rdf#URI): Future[Unit]
 
-  def put[S](url: Rdf#URI, graph: Rdf#Graph, syntax: Syntax[S])(implicit writer: Writer[Rdf#Graph,Try, S]): Future[Unit]
+  def put[S](url: Rdf#URI, graph: Rdf#Graph, syntax: Syntax[S])(implicit writer: Writer[Rdf#Graph, Try, S]): Future[Unit]
 
   def patch(uri: Rdf#URI, remove: Iterable[TripleMatch[Rdf]], add: Iterable[Rdf#Triple]): Future[Void] = ???
 }
@@ -40,15 +40,13 @@ object WebClient {
   val log = LoggerFactory.getLogger(this.getClass)
 }
 
-
 /**
  * This WebClient uses Play's WS
  *
  * @param readerSelector
  * @tparam Rdf
  */
-class WSClient[Rdf <: RDF](readerSelector: ReaderSelector[Rdf, Try], rdfWriter: RDFWriter[Rdf, Try, Turtle])
-                          (implicit ops: RDFOps[Rdf], ec: ExecutionContext) extends WebClient[Rdf] {
+class WSClient[Rdf <: RDF](readerSelector: ReaderSelector[Rdf, Try], rdfWriter: RDFWriter[Rdf, Try, Turtle])(implicit ops: RDFOps[Rdf], ec: ExecutionContext) extends WebClient[Rdf] {
 
   import ops._
 
@@ -119,7 +117,6 @@ class WSClient[Rdf <: RDF](readerSelector: ReaderSelector[Rdf, Try], rdfWriter: 
     }
   }
 
-
   /**
    * Try to read the given body as an RDF graph.
    * If the contentType is not provided left to a default value like text/plain,
@@ -137,11 +134,11 @@ class WSClient[Rdf <: RDF](readerSelector: ReaderSelector[Rdf, Try], rdfWriter: 
   }
 
   private val AllRdfMimeTypes: Set[MimeType] = Set(
-     MimeType("text","turtle"),
-    MimeType("application","rdf+xml"),
-    MimeType("text","n3")
-  )
-
+    MimeType("text", "turtle"),
+    MimeType("application", "rdf+xml"),
+    MimeType("text", "rdf+xml"),
+    MimeType("text", "n3"),
+    MimeType("application", "ntriples"))
 
   /**
    * On some answers the content type header is not appropriately set while the body contains valid RDF.
@@ -154,16 +151,19 @@ class WSClient[Rdf <: RDF](readerSelector: ReaderSelector[Rdf, Try], rdfWriter: 
     val maybeMimeType = maybeContentType.flatMap(ct => MimeType.parse(ct))
     maybeMimeType.map {
       _ match {
-        case MimeType("text", "plain", _) => AllRdfMimeTypes
-        case MimeType("application", "xml", _) => Set(MimeType("application", "xml"), MimeType("application", "rdf+xml"))
-        case MimeType("text", "xml", _) => Set(MimeType("text", "xml"), MimeType("application", "rdf+xml"))
-        case mimeT => Set(mimeT)
+        case MimeType("text", "plain", _)      => AllRdfMimeTypes
+        case MimeType("application", "xml", _) => Set(MimeType("application", "xml"), MimeType("application", "rdf+xml"), MimeType("text", "rdf+xml"))
+        case MimeType("text", "xml", _)        => Set(MimeType("text", "xml"), MimeType("application", "rdf+xml"), MimeType("text", "rdf+xml"))
+        case MimeType(_, "rdf+xml", _)         => Set(MimeType("application", "rdf+xml"), MimeType("text", "rdf+xml")) //banana-rdf has RdfXml mime type specified as MimeType("text", "rdf+xml") instead of MimeType("application", "rdf+xml")
+        case MimeType("text", "n3", _)         => Set(MimeType("application", "ntriples"), MimeType("text", "n3"))  //banana-rdf has NTriples mime type specified as MimeType("application", "ntriples") instead of MimeType("text", "n3")
+        case MimeType(type_, subType, _)       => Set(MimeType(type_, subType)) // to be able to parse the likes of MimeType("text", "turtle", Map( "charset" -> "utf-8"))
+        //        case mimeT                                 => Set(mimeT)
       }
     }.getOrElse(AllRdfMimeTypes)
   }
 
-
   private def readGraph(mimeType: MimeType, body: String, url: String): Try[Rdf#Graph] = {
+
     readerSelector(mimeType) match {
       case Some(reader) => {
         reader.read(new StringReader(body), url) recoverWith {
@@ -182,7 +182,6 @@ class WSClient[Rdf <: RDF](readerSelector: ReaderSelector[Rdf, Try], rdfWriter: 
     mimeTypes.foldLeft(baseTry)(foldFunction)
   }
 
-
   /** This caches results */
   //todo: it's important that if the future is a failure of the right type ( say a timeout execption ) that it retry fetching the resource
   def get(url: Rdf#URI): Future[NamedResource[Rdf]] = {
@@ -190,11 +189,12 @@ class WSClient[Rdf <: RDF](readerSelector: ReaderSelector[Rdf, Try], rdfWriter: 
     c.get(url).getOrElse {
       val result = fetch(url)
       cache.set(c + (url -> result))
-      result.onFailure { case _ =>
-        val futureCache = cache.get
-        futureCache.get(url).foreach { futNamedRes =>
-          if (futNamedRes == result) cache.set(futureCache - url) //todo: slight possibility that we loose a cache
-        }
+      result.onFailure {
+        case _ =>
+          val futureCache = cache.get
+          futureCache.get(url).foreach { futNamedRes =>
+            if (futNamedRes == result) cache.set(futureCache - url) //todo: slight possibility that we loose a cache
+          }
       }
       result
     }
@@ -207,8 +207,7 @@ class WSClient[Rdf <: RDF](readerSelector: ReaderSelector[Rdf, Try], rdfWriter: 
    * @param graph the graph to post
    * @return The Future URL of the created resource
    */
-  def post[S](url: Rdf#URI, slug: Option[String], graph: Rdf#Graph, syntax: Syntax[S])
-             (implicit writer: Writer[Rdf#Graph, Try, S]): Future[Rdf#URI] = {
+  def post[S](url: Rdf#URI, slug: Option[String], graph: Rdf#Graph, syntax: Syntax[S])(implicit writer: Writer[Rdf#Graph, Try, S]): Future[Rdf#URI] = {
     val headers = ("Content-Type" -> syntax.defaultMimeType.mime) :: slug.toList.map(slug => ("Slug" -> slug))
     val futureResp = WS.url(url.toString).withHeaders(headers: _*).post(graph, syntax)
     futureResp.flatMap { resp =>
@@ -236,9 +235,7 @@ class WSClient[Rdf <: RDF](readerSelector: ReaderSelector[Rdf, Try], rdfWriter: 
     }
   }
 
-  override
-  def put[S](url: Rdf#URI, graph: Rdf#Graph, syntax: Syntax[S])
-            (implicit writer: Writer[Rdf#Graph, Try, S]): Future[Unit] = {
+  override def put[S](url: Rdf#URI, graph: Rdf#Graph, syntax: Syntax[S])(implicit writer: Writer[Rdf#Graph, Try, S]): Future[Unit] = {
     val headers = ("Content-Type" -> syntax.defaultMimeType.mime) :: Nil
     val futureResp = WS.url(url.toString).withHeaders(headers: _*).put(graph, syntax)
     futureResp.flatMap { resp =>
@@ -252,7 +249,6 @@ class WSClient[Rdf <: RDF](readerSelector: ReaderSelector[Rdf, Try], rdfWriter: 
   }
 }
 
-
 //case class GraphNHeaders[Rdf<:RDF](graph: Rdf#Graph, remote: ResponseHeaders)
 
 trait FetchException extends BananaException
@@ -264,7 +260,6 @@ object RemoteException {
     RemoteException(msg, ResponseHeaders(resp.status, WS.ningHeadersToMap(resp.ahcResponse.getHeaders)))
   }
 }
-
 
 case class BadStatusException(msg: String, status: Int) extends Exception(msg) with FetchException
 

--- a/app/rww/play/CORSProxy.scala
+++ b/app/rww/play/CORSProxy.scala
@@ -18,6 +18,7 @@ package rww.play
 
 import _root_.play.api.Logger
 import _root_.play.api.mvc.{Result,AnyContent, Controller, Action,Request => PlayRequest}
+import _root_.play.api.http.HeaderNames
 import org.w3.banana.io.{ Writer, WriterSelector}
 import org.w3.banana.{RDFOps, RDF}
 import rww.play.PlayWriterBuilder._
@@ -109,9 +110,9 @@ class CORSProxy[Rdf<:RDF](val wsClient: WebClient[Rdf])
     writerFor(request)(writerSelector).map { writer =>
       namedResource match {
         case ldpr: LDPR[Rdf] => createResultForLDPR(ldpr,writer)
-        case other => UnsupportedMediaType(s"Cannot proxy non rdf resources at present. Request sent ${request.headers.get(play.api.http.HeaderNames.ACCEPT)}")
+        case other => UnsupportedMediaType(s"Cannot proxy non rdf resources at present. Request sent ${request.headers.get(HeaderNames.ACCEPT)}")
       }
-    }.getOrElse(UnsupportedMediaType(s"could not find RDF type of resource at remote location ${request.headers.get(play.api.http.HeaderNames.ACCEPT)}"))
+    }.getOrElse(UnsupportedMediaType(s"could not find RDF type of resource at remote location ${request.headers.get(HeaderNames.ACCEPT)}"))
   }
 
 


### PR DESCRIPTION
Needed this to get [react-foaf](https://github.com/read-write-web/react-foaf) up and running. Perhaps there's a better way to solve this and it should be reported to banana-rdf people. What do you think?
