### PR TITLE
update: headers for CORS

### DIFF
--- a/app/controllers/ldp/ReadWriteWebControllerGeneric.scala
+++ b/app/controllers/ldp/ReadWriteWebControllerGeneric.scala
@@ -79,7 +79,7 @@ trait ReadWriteWebControllerGeneric extends ReadWriteWebControllerTrait {
   private def allowHeaders(authResult: AuthResult[NamedResource[Rdf]]): List[(String, String)] = {
     val modesAllowed = authResult.authInfo.modesAllowed
     val isLDPC =  authResult.result.isInstanceOf[LocalLDPC[_]]
-    val allow = "Allow" -> {
+    val allow = "Access-Control-Allow-Methods" -> {
       val headerStr = modesAllowed.collect {
         case Method.Append =>
           authResult.result match {
@@ -204,7 +204,9 @@ trait ReadWriteWebControllerGeneric extends ReadWriteWebControllerTrait {
         writerFor[Rdf#Graph](request).map { wr =>
           val headers =
             "Access-Control-Allow-Origin" -> "*" ::
-              "Accept-Patch" -> Syntax.SparqlUpdate.mimeTypes.head.mime :: //todo: something that is more flexible
+            "Access-Control-Allow-Headers" -> "content-type, If-Match" ::
+            "Access-Control-Expose-Headers" -> "Etag" ::
+            "Accept-Patch" -> Syntax.SparqlUpdate.mimeTypes.head.mime :: //todo: something that is more flexible
               linkHeaders(ldpr) ::
               commonHeaders
           result(200, wr, Map(headers: _*))(ldpr.relativeGraph)

--- a/app/controllers/ldp/ReadWriteWebControllerGeneric.scala
+++ b/app/controllers/ldp/ReadWriteWebControllerGeneric.scala
@@ -204,7 +204,7 @@ trait ReadWriteWebControllerGeneric extends ReadWriteWebControllerTrait {
         writerFor[Rdf#Graph](request).map { wr =>
           val headers =
             "Access-Control-Allow-Origin" -> "*" ::
-            "Access-Control-Allow-Headers" -> "content-type, If-Match" ::
+            "Access-Control-Allow-Headers" -> "content-type, If-Match, Link, Slug" ::
             "Access-Control-Expose-Headers" -> "Etag" ::
             "Accept-Patch" -> Syntax.SparqlUpdate.mimeTypes.head.mime :: //todo: something that is more flexible
               linkHeaders(ldpr) ::


### PR DESCRIPTION
WARNING:  this version doesn't take care of where the request is coming from, nor if the user actually wants it. I'm not sure how to ensure it in an open decentralized world. A few ideas:
- only enable requests from a user's white list
- prevent requests from shared blacklists
- find a way to ask the user for a confirmation if the site is trusted, and maybe the type of resource he accepts for what method

Any ideas welcome
