### PR TITLE
Add how to let activator know where proper java version resides

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ are no stupid questions!
 Getting going
 =============
 
-* You need at least Java 8 which is [being widely adopted by the Scala community](http://www.infoq.com/news/2014/12/Typesafe-surveys-Java-Adoption)
+* You need at least Java 8 which is [being widely adopted by the Scala community](http://www.infoq.com/news/2014/12/Typesafe-surveys-Java-Adoption). Make sure `JAVA_HOME` ist set properly.
 * clone [this project](https://github.com/stample/rww-play) 
 * run
 ```bash


### PR DESCRIPTION
Seems trivial but while "java --version" told me that java is version 8 activator was using java7. Setting the JAVA_HOME properly fixed that.